### PR TITLE
add: シンボリックリンクによって svn:Externals の機能を補完する方法を確立

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@
 *.exe
 *.out
 *.app
+
+# Linked Includes
+lnc/*.*
+

--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,5 @@
 *.app
 
 # Linked Includes
-lnc/*.*
+inc/*
 

--- a/bin/config.bat
+++ b/bin/config.bat
@@ -1,0 +1,26 @@
+rem コンフィグ設定
+rem startup.bat から呼び出される想定
+set PREFERENCE_BAT=bin\preference.bat
+set XCOMP_BAT=bin\xcomp.bat
+
+rem PREFERENCE ファイルがあれば実行して終了
+if exist %PREFERENCE_BAT% goto exec_pref
+
+rem PREFERENCE ファイルがなければ作成
+rem CYGPATH の設定
+set CYGPATH_DEF=c:\cygwin64
+set /P CYGPATH=Enter cygwin path or skip by setting (%CYGPATH_DEF%) as default :
+if not [%CYGPATH%]==[] goto compiler
+set CYGPATH=%CYGPATH_DEF%
+:compiler
+set COMPILER_DEF=w64
+set /P COMPILER=Select compiler with {w64 or cygwin} or skip by setting (%COMPILER_DEF%) as default :
+if not [%COMPILER%]==[] goto make_pref
+set COMPILER=%COMPILER_DEF%
+:make_pref
+echo set CYGPATH=%CYGPATH%> %PREFERENCE_BAT%
+echo set COMPILER=%COMPILER%>> %PREFERENCE_BAT%
+
+:exec_pref
+call %PREFERENCE_BAT%
+call %XCOMP_BAT% %COMPILER%

--- a/bin/linclude.bat
+++ b/bin/linclude.bat
@@ -1,0 +1,6 @@
+@echo off
+%~d0
+cd %~dp0\..\inc\
+for /F %%f in (..\bin\lincludes.txt) do (del %%~nxf && mklink %%~nxf ..\prj\%%f)
+pause
+

--- a/bin/lincludes.txt
+++ b/bin/lincludes.txt
@@ -1,0 +1,3 @@
+sys\itstypes.h
+sys\itsut.h
+sys\appinfo.h

--- a/bin/xcomp.bat
+++ b/bin/xcomp.bat
@@ -1,0 +1,9 @@
+@echo off
+rem クロスコンパイラの選択
+set GPP=x86_64-w64-mingw32-g++
+set CSET=932
+if [%1]==[w64] goto exec
+set GPP=g++
+set CSET=65001
+:exec
+chcp %CSET%>nul

--- a/inc/typename.h
+++ b/inc/typename.h
@@ -1,0 +1,1 @@
+../prj/sys/typename.h

--- a/prj/sys/appinfo.h
+++ b/prj/sys/appinfo.h
@@ -1,0 +1,50 @@
+//
+//  title: appinfo.h
+//  description: アプリケーション情報
+//  author: Shigeyuki Itoh
+//  date: 20-05-03
+//
+
+#ifndef APPINFO_H
+#define APPINFO_H
+
+// アプリケーションの情報
+struct AppInfo
+{
+    // アプリケーション名
+    char const* appname;
+    // バージョン情報
+    struct Version
+    {
+        // メジャー番号
+        int maj;
+
+        // マイナー番号
+        int min;
+
+        // リビジョン番号
+        int rev;
+
+        // コンストラクタ
+        Version(int v1, int v2, int r) : maj(v1), min(v2), rev(r) {}
+    };
+
+    // 有効引数の数
+    int argnum;
+
+    // 引数情報
+    struct Args
+    {
+        // ノーテーション
+        char const* note;
+
+        // 説明
+        char const* desc;
+
+        // オプショナル（省略可能）
+        bool optional;
+    };
+};
+
+
+#endif

--- a/prj/sys/itstypes.h
+++ b/prj/sys/itstypes.h
@@ -1,0 +1,53 @@
+//
+// title: itstypes.h
+//
+// author: Shigeyuki Itoh
+// date: 20-05-02
+//
+
+// overview: 共通型定義ヘッダ
+// description:
+//  cygwin-gcc / x86_64-w64-mingw32-gcc のクロスコンパイル環境における
+//  型に関する仕様の差分を吸収することを目的としたヘッダファイル
+
+#ifndef ITSTYPES_H
+#define ITSTYPES_H
+
+typedef signed char s8;
+typedef unsigned char u8;
+typedef signed short s16;
+typedef unsigned short u16;
+typedef signed int s32;
+typedef unsigned int u32;
+typedef float f32;
+typedef double f64;
+
+// cygwin-gcc
+#ifdef CYGWIN_GCC
+
+typedef signed long s64;
+typedef unsigned long u64;
+
+#define PI64d(...) "%" #__VA_ARGS__ "ld"
+#define PI64u(...) "%" #__VA_ARGS__ "lu"
+#define PI64X(...) "%" #__VA_ARGS__ "lX"
+#define PI64x(...) "%" #__VA_ARGS__ "lx"
+
+#endif
+
+// x86_64-w64-mingw32-gcc
+#ifdef W64_GCC
+
+typedef signed long long s64;
+typedef unsigned long long u64;
+
+#define PI64d(...) "%" #__VA_ARGS__ "lld"
+#define PI64u(...) "%" #__VA_ARGS__ "llu"
+#define PI64X(...) "%" #__VA_ARGS__ "llX"
+#define PI64x(...) "%" #__VA_ARGS__ "llx"
+
+#endif
+
+#define PSIZET(...) PI64u(__VA_ARGS__)
+
+#endif // ITSTYPES_H

--- a/prj/sys/itsut.h
+++ b/prj/sys/itsut.h
@@ -1,0 +1,269 @@
+// title: itsut.h
+//
+// author: Shigeyuki Itoh
+// date: 20-05-12
+//
+
+// overview: 単体テストユーティリティ
+// description:
+//  単体テストのコードで利用されることを前提としている
+//  テストする側なので何にも依存しない
+
+#if UNIT_TESTING
+
+#ifndef ITS_UNIT_TEST_UTILITY_H
+#define ITS_UNIT_TEST_UTILITY_H
+
+#include <functional>
+#include <cstdio>
+#include <cstring>
+
+namespace its
+{
+
+namespace ut
+{
+
+// ユニットテストのログを出力するユニットテスト
+class Logger
+{
+private:
+    static int const kIndentDepth = 1024;
+
+    // ログインデント
+    int m_indent;
+
+    // コールスタックバッファの長さ
+    int m_length;
+
+    // コールスタック
+    std::unique_ptr<char const*[]> m_cstack;
+
+    // シングルトンインスタンス
+    Logger* s_instance = nullptr;
+
+    Logger() : m_indent(0), m_length(kIndentDepth), m_cstack(new char const*[kIndentDepth])
+    {
+    }
+
+public:
+    Logger* Instance()
+    {
+        if(s_instance == nullptr)
+        {
+            s_instance = new Logger();
+        }
+        return s_instance;
+    }
+
+    // Enter 処理
+    void Enter(char const* func)
+    {
+        // 次スタックを積んだらあふれる場合：バッファを増やす
+        if(m_indent >= m_length)
+        {
+            int len = m_length;
+            m_length += kIndentDepth;
+            char const*[] tmp = m_cstack.release();
+            m_cstack.reset(new char const*[m_length]);
+            memcpy(m_cstack.get(), tmp, sizeof(char const*) * len);
+            memset(&m_cstack[m_indent], nullptr, m_length - m_indent);
+        }
+
+        
+    }
+
+    // インデント付きで
+};
+
+// テスト失敗例外
+//
+//  使用例
+//      try
+//      {
+//          : // test code
+//          :
+//          // in case of exception
+//          throw FailureException(__func__, <cause>, <action to be executed>
+//      }
+//      catch(FailureException& e)
+//      {
+//          return e();    // action is excuted here
+//      }
+//
+class FailureException
+{
+public:
+    // デフォルト終了コード
+    static int const kDefaultExitCode = -1;
+
+private:
+    // 失敗した関数名
+    char const* m_at;
+
+    // 原因
+    char const* m_cause;
+
+public:
+
+    // コンストラクタ
+    FailureException(char const* a, char const* c) : m_at(a), m_cause(c)
+    {
+
+                                            #if UNIT_TEST_TEST
+                                            printf("\n");
+                                            printf("ut:%s::ctor\n", __func__);
+                                            printf("ut:\tm_at:%s\n", m_at);
+                                            printf("ut:\tm_cause:%s\n", m_cause);
+                                            #endif
+
+    }
+
+    // 関数オペレータ
+    //  キャッチしたほうが呼び出すことを想定している
+    int operator ()() const
+    {
+        fprintf(stderr, "Unit test failure\n\tat:%s()\n\tcause:%s\n", m_at, m_cause);
+        return kDefaultExitCode;
+    }
+
+    // 発生位置
+    char const* At() const { return m_at; }
+
+    // 発生原因
+    char const* Cause() const { return m_cause; }
+};
+
+// 比較処理
+//  vl: 左辺値
+//  vr: 右辺値
+//  nl: 左辺値変数名
+//  nr: 右辺値変数名
+//  from: 呼出元関数名
+//  fmt: 型
+void compare(auto vl, auto vr, char const* nl, char const* nr, char const* from, char const* fmt, char const* cmp, std::function<bool()> judge)
+{
+                                            #if UNIT_TEST_TEST
+                                            printf("ut:%s\n", __func__);
+                                            printf("ut:\tnl:\"%s\", nr:\"%s\"\n", nl, nr);
+                                            printf("ut:\tfrom:%s\n", from);
+                                            printf("ut:\tfmt:%s\n", fmt);
+                                            printf("ut:\tcmp:%s\n", cmp);
+                                            #endif
+    // キャプション
+    char const* tmpl = "%%s(): test{ %%s (%s) %%s (%s) %%s } ";
+    char format[strlen(fmt) * 2 + strlen(tmpl) + 1];
+                                            #if UNIT_TEST_TEST
+                                            printf("ut:\tsprintf(format, \"%s\", fmt:\"%s\", fmt:\"%s\");\n", tmpl, fmt, fmt);
+                                            #endif
+    sprintf(format, tmpl, fmt, fmt);
+                                            #if UNIT_TEST_TEST
+                                            printf("ut:\tformat[%llu] =\"%s\"\n", sizeof(format), format);
+                                            #endif
+    printf(format, from, nl, vl, cmp, vr, nr);
+
+    // 型比較
+    if(typeid(vl) != typeid(vr)) throw FailureException(from, "type miss match");
+
+    // パスしなかったら例外スロー
+    if(judge() == false) throw FailureException(from, "comparison failed");
+
+    // 合格
+    printf("--> passed\n");
+}
+
+} // namespace ut
+
+} // namaespace its
+
+#if 0
+// NULL チェックマクロ
+//  v が nullptr だったら FailureException を投げる
+#define ITS_UT_NUL(v) if(v == nullptr) throw its::ut::FailureException(__func__, #v " is null")
+
+// 比較マクロ
+//  l: 左辺値
+//  c: 比較演算子
+//  r: 右辺値
+//  f: フォーマット
+#define ITS_UT_CMP(l, c, r, f, j)  its::ut::compare(l, r, #l, #r, __func__, f, #c, j)
+
+// 文字列比較マクロ
+//  l: 左辺値
+//  c: 比較演算子
+//  r: 右辺値
+//  f: フォーマット
+#define ITS_UT_STR(l, c, r) ITS_UT_NUL(l); ITS_UT_NUL(r); ITS_UT_CMP(l, c, r, "%s", ([&l, &r] () -> bool { return strcmp(l, r) c 0; }))
+
+// 数値比較マクロ
+//  l: 左辺値
+//  c: 比較演算子
+//  r: 右辺値
+//  f: フォーマット
+#define ITS_UT_VAL(l, c, r, f) ITS_UT_CMP(l, c, r, f, ([&l, &r] () -> bool { return l c r; }))
+
+
+
+
+// EQual
+#define ITS_UT_EQc(l, r) ITS_UT_VAL(l, ==, r, "%c")
+#define ITS_UT_EQi(l, r) ITS_UT_VAL(l, ==, r, "%d")
+#define ITS_UT_EQu(l, r) ITS_UT_VAL(l, ==, r, "%u")
+#define ITS_UT_EQx(l, r) ITS_UT_VAL(l, ==, r, "%x")
+#define ITS_UT_EQf(l, r) ITS_UT_VAL(l, ==, r, "%f")
+#define ITS_UT_EQd(l, r) ITS_UT_VAL(l, ==, r, "%lf")
+#define ITS_UT_EQs(l, r) ITS_UT_STR(l, ==, r)
+
+// NotEqual
+#define ITS_UT_NEc(l, r) ITS_UT_VAL(l, !=, r, "%c")
+#define ITS_UT_NEi(l, r) ITS_UT_VAL(l, !=, r, "%d")
+#define ITS_UT_NEu(l, r) ITS_UT_VAL(l, !=, r, "%u")
+#define ITS_UT_NEx(l, r) ITS_UT_VAL(l, !=, r, "%x")
+#define ITS_UT_NEf(l, r) ITS_UT_VAL(l, !=, r, "%f")
+#define ITS_UT_NEd(l, r) ITS_UT_VAL(l, !=, r, "%lf")
+#define ITS_UT_NEs(l, r) ITS_UT_STR(l, !=, r)
+
+// LessEqual
+#define ITS_UT_LEc(l, r) ITS_UT_VAL(l, <=, r, "%c")
+#define ITS_UT_LEi(l, r) ITS_UT_VAL(l, <=, r, "%d")
+#define ITS_UT_LEu(l, r) ITS_UT_VAL(l, <=, r, "%u")
+#define ITS_UT_LEx(l, r) ITS_UT_VAL(l, <=, r, "%x")
+#define ITS_UT_LEf(l, r) ITS_UT_VAL(l, <=, r, "%f")
+#define ITS_UT_LEd(l, r) ITS_UT_VAL(l, <=, r, "%lf")
+
+// GreaterEqual
+#define ITS_UT_GEc(l, r) ITS_UT_VAL(l, >=, r, "%c")
+#define ITS_UT_GEi(l, r) ITS_UT_VAL(l, >=, r, "%d")
+#define ITS_UT_GEu(l, r) ITS_UT_VAL(l, >=, r, "%u")
+#define ITS_UT_GEx(l, r) ITS_UT_VAL(l, >=, r, "%x")
+#define ITS_UT_GEf(l, r) ITS_UT_VAL(l, >=, r, "%f")
+#define ITS_UT_GEd(l, r) ITS_UT_VAL(l, >=, r, "%lf")
+
+// LessThan
+#define ITS_UT_LTc(l, r) ITS_UT_VAL(l, <, r, "%c")
+#define ITS_UT_LTi(l, r) ITS_UT_VAL(l, <, r, "%d")
+#define ITS_UT_LTu(l, r) ITS_UT_VAL(l, <, r, "%u")
+#define ITS_UT_LTx(l, r) ITS_UT_VAL(l, <, r, "%x")
+#define ITS_UT_LTf(l, r) ITS_UT_VAL(l, <, r, "%f")
+#define ITS_UT_LTd(l, r) ITS_UT_VAL(l, <, r, "%lf")
+
+// GreaterThan
+#define ITS_UT_GTc(l, r) ITS_UT_VAL(l, >, r, "%c")
+#define ITS_UT_GTi(l, r) ITS_UT_VAL(l, >, r, "%d")
+#define ITS_UT_GTu(l, r) ITS_UT_VAL(l, >, r, "%u")
+#define ITS_UT_GTx(l, r) ITS_UT_VAL(l, >, r, "%x")
+#define ITS_UT_GTf(l, r) ITS_UT_VAL(l, >, r, "%f")
+#define ITS_UT_GTd(l, r) ITS_UT_VAL(l, >, r, "%lf")
+
+#endif
+
+#endif  // ITS_UNIT_TEST_UTILITY_H
+
+#define ITS_UT_COMPARE  its::ut::compare
+
+#else
+
+#define ITS_UT_COMPARE
+
+#endif  // UNIT_TESTING
+

--- a/prj/sys/typename.h
+++ b/prj/sys/typename.h
@@ -1,0 +1,133 @@
+//
+//  typeid.name の型名記号を解析して型名に変換するクラス
+//
+//  20-05-16
+//  Shigeyuki Itoh
+//
+
+
+
+
+#ifndef ITS_TYPE_NAME_PARSER
+#define ITS_TYPE_NAME_PARSER
+
+#include "itstypes.h"
+
+namespace its
+{
+
+// 型名を文字列で取得する
+//
+//  char const* name = TypeName(変数);
+//  ※ printf の %s の引数にする場合 char const* へのキャストが必要
+class TypeName
+{
+private:
+    std::unique_ptr<char[]> m_string;
+
+    // 型名のパース
+    //  val: 値
+    //  lambda: ヒットするたびに呼び出されるラムダ式
+    void parse(auto val, std::function<void(char const* str)> lambda)
+    {
+        // 型変換リスト
+        //  [0] が Key
+        //  [2] が Value
+        static char const* types[] =
+        {
+            "c:char",
+            "s:short",
+            "i:int",
+            "l:long",
+            "x:long long",
+            "h:unsigned char",
+            "t:unsigned short",
+            "j:unsinged int",
+            "m:unsigned long",
+            "y:unsigned long long",
+            "f:float",
+            "d:double"
+        };
+
+        // 修飾子変換リスト
+        //  [0] が Key
+        //  [2] が Value
+        static char const* decors[] =
+        {
+            "K: const",
+            "P:*"
+        };
+
+        // 型名キーワードを取得
+        char const* type = typeid(val).name();
+        
+        // 型名キーワードの先頭位置（最初は 0）
+        size_t tail = strlen(type) - 1;
+        bool known = false;
+
+        // 一致するものを探す
+        for(char const* t : types)
+        {
+            if(t[0] == type[tail])
+            {
+                lambda(&t[2]);
+                // 見つかったフラグ
+                known = true;
+                break;
+            }
+        }
+        // 不明の型の場合
+        if(known == false)
+        {
+            // [] で囲ってとりあえず表示
+            //  見つけ次第リストを増やす
+            char unknown[] = "[.]";
+            unknown[1] = type[tail];
+            lambda(unknown);
+        }
+
+        // 型名キーワードが 1 文字じゃない場合
+        if(tail > 0)
+        {
+            // 修飾子の追記
+            for(size_t i = 0; i < tail; i++)
+            {
+                // 一致するものを探す
+                for(char const* d : decors)
+                {
+                    if(d[0] == type[tail - i])
+                    {
+                        lambda(&d[2]);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+public:
+    // コンストラクタ
+    //  val :対象の変数
+    //  fmt :つけたい装飾
+    //      :printf フォーマット
+    //      :%s を一つだけ含む
+    TypeName(auto val, char const* fmt = nullptr) : m_string()
+    {
+        size_t len = 1;
+        parse(val, [&] (char const* str) { len += strlen(str); });
+        std::unique_ptr<char[]> name(new char[len]);
+        name[0] = '\0';
+        parse(val, [&] (char const* str) { strcat(name.get(), str); });
+
+        if(fmt == nullptr)  { fmt = "%s"; }
+        m_string.reset(new char[strlen(fmt) + len]);
+        sprintf(m_string.get(), fmt, name.get());
+    }
+
+    // char const による参照
+    operator char const* () { return m_string.get(); }
+};
+
+} // namespace its
+
+#endif // ITS_TYPE_NAME_PARSER

--- a/prj/sys/unit_test/mk.bat
+++ b/prj/sys/unit_test/mk.bat
@@ -1,0 +1,11 @@
+rem do it
+rem 単体テストのテスト環境
+
+%GPP% -I ../../../inc/ -D UNIT_TESTING=1 -D UNIT_TEST_TEST=1 -m64 --std=c++14 -Wall unit_test.cpp --static -l stdc++ 2> error.log
+if errorlevel, 1 goto err
+a.exe > test.log
+echo eixt code = %errorlevel%
+exit /b 0
+:err
+start error.log
+

--- a/prj/sys/unit_test/unit_test.cpp
+++ b/prj/sys/unit_test/unit_test.cpp
@@ -1,0 +1,44 @@
+//
+// 単体テストのテストコード
+//
+//  伊藤茂行
+//  20-06-18
+
+#include "itsut.h"
+
+#if UNIT_TESTING
+int main()
+{
+    try
+    {
+        printf("hello unit_test world!!\n");
+        int v1 = 4;
+        int v2 = 5;
+        ITS_UT_NEi(v1, v2);
+        ITS_UT_LTi(v1, v2);
+        ITS_UT_LEi(v1, v2);
+        ITS_UT_GTi(v2, v1);
+        ITS_UT_GEi(v2, v1);
+        //ITS_UT_EQi(v1, v2);
+        char const* s1 = "hello";
+        char const* s2 = "world";
+        char const* s3 = "hello";
+        //char const* s4 = nullptr;
+        ITS_UT_EQs(s1, s3);
+        ITS_UT_NEs(s1, s2);
+        //ITS_UT_EQs(s1, s2);
+        //ITS_UT_EQs(s1, s4);
+        return 0;
+    }
+    catch(its::ut::FailureException& e)
+    {
+        e();
+        return 1;
+    }
+}
+#else
+int main()
+{
+    return 0;
+}
+#endif

--- a/startup.bat
+++ b/startup.bat
@@ -1,0 +1,13 @@
+@echo off
+%~d0
+cd %~p0
+echo ------------------------------------------------
+echo cygwin command-line tool development environment
+echo ------------------------------------------------
+
+call bin\config.bat
+
+path=%path%;%CYGPATH%\bin;bin
+prompt=$T$H$H$H$H$H$H[$p]
+cmd /K
+


### PR DESCRIPTION
svn:Externals のように、リンクを作りたかったので、検証してみた。
シンボリックリンクで、擬似的に行うことができるが、
実際、Externals のように相互のリンクは不可能だといえる。
リンク元の inc 側で編集すると、git はリンク元と先両方が、
変更として扱われ、リンク元の方をコミットしてしまうと、
その時点でリンクではなく別ファイルとして扱われてしまう。
なので、双方向は諦めて、単方向にする。
.gitignore で、inc 以下を無視対象にすることで、
inc 側のコミットができなくしてしまうのが正しい。